### PR TITLE
fix: always crash if can't resolve metadata

### DIFF
--- a/.changeset/serious-buses-draw.md
+++ b/.changeset/serious-buses-draw.md
@@ -1,0 +1,5 @@
+---
+"termost": patch
+---
+
+Fixes always crash if can't resolve metadata

--- a/termost/src/termost.ts
+++ b/termost/src/termost.ts
@@ -46,21 +46,35 @@ export function termost<Values extends ObjectLikeConstraint = EmptyObject>(
 	metadata: Partial<PackageMetadata> | string,
 	callbacks: TerminationCallbacks = {},
 ) {
-	const paramsMetadata: Partial<PackageMetadata> = isObject(metadata)
+	let { name, description, version } = isObject(metadata)
 		? metadata
-		: { description: metadata };
+		: {
+				name: undefined,
+				description: metadata,
+				version: undefined,
+		  };
 
-	const packageMetadata = getPackageMetadata();
-	const programName = paramsMetadata.name ?? packageMetadata.name;
-	const { command = programName, operands, options } = getArguments();
+	if (
+		name === undefined ||
+		description === undefined ||
+		version === undefined
+	) {
+		const packageMetadata = getPackageMetadata();
+
+		name ??= packageMetadata.name;
+		description ??= packageMetadata.description;
+		version ??= packageMetadata.version;
+	}
+
+	const { command = name, operands, options } = getArguments();
 
 	setGracefulListeners(callbacks);
 
 	return createProgram<Values>({
-		name: programName,
-		description: paramsMetadata.description ?? packageMetadata.description,
+		name,
+		description,
 		argv: { command, operands, options },
-		version: paramsMetadata.version ?? packageMetadata.version,
+		version,
 	});
 }
 


### PR DESCRIPTION
Hello @adbayb,  

termost tries to automatically resolve the `name`, `version` and `description` even when explicitely provided.  
This makes the `Termost was unable to retrieve automatically the package name and version. To fix it, use `termost({ name, description, version })` to define them manually.` error unavoidable.  

This PR fixes that.  